### PR TITLE
removed margin from body

### DIFF
--- a/nav.css
+++ b/nav.css
@@ -1,3 +1,5 @@
+body{margin:0;}
+
 .navBar{
   /*Removes Bullet Points from List Objects from navBar*/
   list-style: none;


### PR DESCRIPTION
To make a cleaner looking navigation bar, you would want to remove the margin from the sides of the navigation bar. This is mainly because of the body's margin.